### PR TITLE
Added backwards compatibility with DRF 2.4.X, fixed media_type pass through

### DIFF
--- a/rest_framework_ember/pagination.py
+++ b/rest_framework_ember/pagination.py
@@ -4,8 +4,11 @@ from rest_framework.templatetags.rest_framework import replace_query_param
 
 from rest_framework_ember.utils import get_resource_name
 
+# DRF 2.4.X compatibility.
+ReadOnlyField = getattr(serializers, 'ReadOnlyField', serializers.Field)
 
-class NextPageLinkField(serializers.ReadOnlyField):
+
+class NextPageLinkField(ReadOnlyField):
     """
     Field that returns a link to the next page in paginated results.
     """
@@ -20,7 +23,7 @@ class NextPageLinkField(serializers.ReadOnlyField):
         return replace_query_param(url, self.page_field, page)
 
 
-class NextPageField(serializers.ReadOnlyField):
+class NextPageField(ReadOnlyField):
     """
     Field that returns a link to the next page in paginated results.
     """
@@ -32,7 +35,7 @@ class NextPageField(serializers.ReadOnlyField):
         return value.next_page_number()
 
 
-class PreviousPageLinkField(serializers.ReadOnlyField):
+class PreviousPageLinkField(ReadOnlyField):
     """
     Field that returns a link to the previous page in paginated results.
     """
@@ -47,7 +50,7 @@ class PreviousPageLinkField(serializers.ReadOnlyField):
         return replace_query_param(url, self.page_field, page)
 
 
-class PreviousPageField(serializers.ReadOnlyField):
+class PreviousPageField(ReadOnlyField):
     """
     Field that returns a link to the previous page in paginated results.
     """
@@ -59,7 +62,7 @@ class PreviousPageField(serializers.ReadOnlyField):
         return value.previous_page_number()
 
 
-class PageField(serializers.ReadOnlyField):
+class PageField(ReadOnlyField):
     """
     Field that returns a link to the previous page in paginated results.
     """
@@ -76,8 +79,8 @@ class PaginationSerializer(pagination.BasePaginationSerializer):
     page = PageField(source='*')
     previous = PreviousPageField(source='*')
     previous_link = PreviousPageLinkField(source='*')
-    count = serializers.ReadOnlyField(source='paginator.count')
-    total = serializers.ReadOnlyField(source='paginator.num_pages')
+    count = ReadOnlyField(source='paginator.count')
+    total = ReadOnlyField(source='paginator.num_pages')
 
 
 class EmberPaginationSerializer(PaginationSerializer):

--- a/rest_framework_ember/parsers.py
+++ b/rest_framework_ember/parsers.py
@@ -27,7 +27,7 @@ class JSONParser(parsers.JSONParser):
         Parses the incoming bytestream as JSON and returns the resulting data
         """
         result = super(JSONParser, self).parse(stream, media_type=media_type,
-                                                    parser_context=None)
+                                               parser_context=parser_context)
         resource = result.get(get_resource_name(parser_context.get('view', None)))
         return format_keys(resource, 'underscore')
 

--- a/rest_framework_ember/parsers.py
+++ b/rest_framework_ember/parsers.py
@@ -26,7 +26,7 @@ class JSONParser(parsers.JSONParser):
         """
         Parses the incoming bytestream as JSON and returns the resulting data
         """
-        result = super(JSONParser, self).parse(stream, media_type=None,
+        result = super(JSONParser, self).parse(stream, media_type=media_type,
                                                     parser_context=None)
         resource = result.get(get_resource_name(parser_context.get('view', None)))
         return format_keys(resource, 'underscore')

--- a/rest_framework_ember/utils.py
+++ b/rest_framework_ember/utils.py
@@ -29,7 +29,9 @@ def get_resource_name(view):
             name = format_keys(name)
             resource_name = name[:1].lower() + name[1:]
 
-    if getattr(settings, 'REST_EMBER_FORMAT_KEYS', False):
+    if (getattr(settings, 'REST_EMBER_FORMAT_KEYS', False)
+        and isinstance(resource_name, basestring)):
+
         return inflection.camelize(resource_name, False)
 
     return resource_name

--- a/rest_framework_ember/utils.py
+++ b/rest_framework_ember/utils.py
@@ -29,6 +29,9 @@ def get_resource_name(view):
             name = format_keys(name)
             resource_name = name[:1].lower() + name[1:]
 
+    if getattr(settings, 'REST_EMBER_FORMAT_KEYS', False):
+        return inflection.camelize(resource_name, False)
+
     return resource_name
 
 
@@ -39,18 +42,18 @@ def format_keys(obj, format_type=None):
 
     :format_type: Either 'camelize' or 'underscore'
     """
-    if getattr(settings, 'REST_EMBER_FORMAT_KEYS', False)\
-        and format_type in ('camelize', 'underscore'):
+    if (getattr(settings, 'REST_EMBER_FORMAT_KEYS', False)
+        and format_type in ('camelize', 'underscore')):
         
         if isinstance(obj, dict):
             formatted = {}
             for key, value in obj.items():
                 if format_type == 'camelize':
-                    formatted[inflection.camelize(key, False)]\
-                        = format_keys(value, format_type)
+                    (formatted[inflection.camelize(key, False)]
+                        = format_keys(value, format_type))
                 elif format_type == 'underscore':
-                    formatted[inflection.underscore(key)]\
-                        = format_keys(value, format_type)
+                    (formatted[inflection.underscore(key)]
+                        = format_keys(value, format_type))
             return formatted
         if isinstance(obj, list):
             return [format_keys(item, format_type) for item in obj]
@@ -64,7 +67,9 @@ def format_resource_name(obj, name):
     """
     Pluralize the resource name if more than one object in results.
     """
-    if getattr(settings, 'REST_EMBER_PLURALIZE_KEYS', False) and isinstance(obj, list):
+    if (getattr(settings, 'REST_EMBER_PLURALIZE_KEYS', False)
+        and isinstance(obj, list)):
+        
         return inflection.pluralize(name) if len(obj) > 1 else name
     else:
         return name

--- a/rest_framework_ember/utils.py
+++ b/rest_framework_ember/utils.py
@@ -42,18 +42,18 @@ def format_keys(obj, format_type=None):
 
     :format_type: Either 'camelize' or 'underscore'
     """
-    if (getattr(settings, 'REST_EMBER_FORMAT_KEYS', False)
-        and format_type in ('camelize', 'underscore')):
+    if getattr(settings, 'REST_EMBER_FORMAT_KEYS', False)\
+        and format_type in ('camelize', 'underscore'):
         
         if isinstance(obj, dict):
             formatted = {}
             for key, value in obj.items():
                 if format_type == 'camelize':
-                    (formatted[inflection.camelize(key, False)]
-                        = format_keys(value, format_type))
+                    formatted[inflection.camelize(key, False)]\
+                        = format_keys(value, format_type)
                 elif format_type == 'underscore':
-                    (formatted[inflection.underscore(key)]
-                        = format_keys(value, format_type))
+                    formatted[inflection.underscore(key)]\
+                        = format_keys(value, format_type)
             return formatted
         if isinstance(obj, list):
             return [format_keys(item, format_type) for item in obj]
@@ -69,7 +69,7 @@ def format_resource_name(obj, name):
     """
     if (getattr(settings, 'REST_EMBER_PLURALIZE_KEYS', False)
         and isinstance(obj, list)):
-        
+
         return inflection.pluralize(name) if len(obj) > 1 else name
     else:
         return name

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='BSD',
     keywords="EmberJS Django REST",
     packages=find_packages(),
-    install_requires=['django', 'djangorestframework >= 3.0.0', 'inflection' ],
+    install_requires=['django', 'djangorestframework >= 2.4.0', 'inflection' ],
     platforms=['any'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
ReadOnlyField is only available in DRF 3.0+ and was causing backwards incompatibility. Also fixed media_type pass through as noted in open issue: https://github.com/ngenworks/rest_framework_ember/issues/17