### PR TITLE
Use plural key for list responses, even if the list is 0 or 1 records long

### DIFF
--- a/example/tests/test_format_keys.py
+++ b/example/tests/test_format_keys.py
@@ -36,7 +36,7 @@ class FormatKeysSetTests(TestBase):
 
         user = get_user_model().objects.all()[0]
         expected = {
-            u'user': [{
+            u'users': [{
                 u'id': user.pk,
                 u'firstName': user.first_name,
                 u'lastName': user.last_name,
@@ -47,8 +47,9 @@ class FormatKeysSetTests(TestBase):
         json_content = json.loads(response.content)
         meta = json_content.get('meta')
 
-        self.assertEquals(expected.get('user'), json_content.get('user'))
-        self.assertEqual('http://testserver/user-viewset/?page=2', meta.get('nextLink'))
+        self.assertEquals(expected.get('users'), json_content.get('users'))
+        self.assertEqual('http://testserver/user-viewset/?page=2',
+            meta.get('nextLink'))
 
     def test_pluralization(self):
         """
@@ -74,3 +75,12 @@ class FormatKeysSetTests(TestBase):
 
         json_content = json.loads(response.content)
         self.assertEquals(expected.get('users'), json_content.get('users'))
+
+        #test that the key is still pluralized when there are no records for the
+        #model, as long as the endpoint serves a list
+        get_user_model().objects.all().delete()
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, 200)
+
+        json_content = json.loads(response.content)
+        self.assertEqual(json_content.get('users'), [])

--- a/rest_framework_ember/utils.py
+++ b/rest_framework_ember/utils.py
@@ -65,6 +65,6 @@ def format_resource_name(obj, name):
     Pluralize the resource name if more than one object in results.
     """
     if getattr(settings, 'REST_EMBER_PLURALIZE_KEYS', False) and isinstance(obj, list):
-        return inflection.pluralize(name) if len(obj) > 1 else name
+        return inflection.pluralize(name)
     else:
         return name

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+if __name__ == "__main__":
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'example.settings'
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests([
+        'example.tests'])
+    sys.exit(bool(failures))


### PR DESCRIPTION
The Ember documentation is a little ambiguous on this point, but I would expect an endpoint that returns a list to always use the same key for its content. The client making the request has no knowledge ahead of time about the number of requests, so it wouldn't know whether to look for, say, "user" instead of "users." Or, to put it another way, if I say "give me a list of all the users," I'll be expecting a list, even if the list turns out to be empty or only one record long.

Granted, Ember Data *does* handle a singular key correctly in this case, but it still seems like it would be more consistent to use the plural key -- other clients consuming the application's API may not be as savvy.

I've also added a standalone test runner (runtests.py) to make running the library's tests a little easier -- this way, a contributor won't need to create a separate Django project to run the test suite.

Looking forward to your thoughts. Also, thanks for your great work on this project so far!